### PR TITLE
pointed screenshot links to imgur mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Fukuzatsu was created by [Coraline Ada Ehmke](http://where.coraline.codes/) and 
 
 These are screenshots of the `-f html` output. First, the overall project summary:
 
-![Project Summary](https://gitlab.com/coraline/fukuzatsu/raw/master/doc/images/overview.png)
+![Project Summary](http://i.imgur.com/ekrSAl5.png)
 
 Then the detail view of a single class:
 
-![Project Summary](https://gitlab.com/coraline/fukuzatsu/raw/master/doc/images/details.png)
+![Project Summary](http://i.imgur.com/FGRSmh8.png)
 
 ## Installation
 


### PR DESCRIPTION
I noticed the open issue on "Not Found" screenshots in the README. I located another copy of the README on GitLab, downloaded the relevant screenshots from it, uploaded them to Imgur, and updated the links accordingly.

I'm not sure if this type of solution maps with your team's workflow or resource maintenance strategy - it feels somewhat like a "Band-Aid" to me - but it fixes the issue presented, and that might be good enough for now.
